### PR TITLE
adding support for "ids" keyword

### DIFF
--- a/src/main/java/com/nfl/glitr/registry/TypeRegistry.java
+++ b/src/main/java/com/nfl/glitr/registry/TypeRegistry.java
@@ -538,6 +538,10 @@ public class TypeRegistry implements TypeResolver {
         } else if (type instanceof ParameterizedType) {
             return getGraphQLTypeForOutputParameterizedType(type, name, fromInterface);
         } else if (((Class) type).isArray()) {
+            // ids is also magical
+            if (name != null && name.equals("ids")) {
+                return new GraphQLList(GraphQLID);
+            }
             return createListOutputTypeFromArrayType(type, fromInterface);
         } else if (fromInterface) { // to avoid circular references we will process the Interface field type later
             return new GraphQLTypeReference(((Class) type).getSimpleName());
@@ -580,6 +584,10 @@ public class TypeRegistry implements TypeResolver {
         } else if (type instanceof ParameterizedType) {
             return getGraphQLTypeForInputParameterizedType(type);
         } else if (((Class) type).isArray()) {
+            // ids is also magical
+            if (name != null && name.equals("ids")) {
+                return new GraphQLList(GraphQLID);
+            }
             return createListInputTypeFromArrayType(type);
         }
         return lookupInput((Class) type);

--- a/src/test/groovy/com/nfl/glitr/data/query/QueryType.java
+++ b/src/test/groovy/com/nfl/glitr/data/query/QueryType.java
@@ -20,4 +20,7 @@ public class QueryType {
 
     @GlitrArgument(name = "id", type = String.class, nullable = false)
     public com.nfl.glitr.relay.Node getNode() { return null; }
+
+    @GlitrArgument(name = "ids", type = String[].class, nullable = false)
+    public List<com.nfl.glitr.relay.Node> getNodes() { return null; }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/TypeRegistryIntegrationTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/TypeRegistryIntegrationTest.groovy
@@ -23,12 +23,13 @@ class TypeRegistryIntegrationTest extends Specification {
         then:
         type.name == QueryType.class.getSimpleName()
         type.description == "No Description"
+
         // Relay Identifiable field
         def fieldDef = type.fieldDefinitions[0]
         fieldDef.name == "node"
         fieldDef.description == "No Description"
         fieldDef.type instanceof GraphQLInterfaceType
-        def GraphQLInterfaceType fieldDefType = (GraphQLInterfaceType) fieldDef.type
+        GraphQLInterfaceType fieldDefType = (GraphQLInterfaceType) fieldDef.type
         fieldDefType.name == "Node"
         fieldDefType.description == "An object with an ID"
         fieldDefType.fieldDefinitions.size() == 1
@@ -40,12 +41,30 @@ class TypeRegistryIntegrationTest extends Specification {
         inputWrappedType.name == "ID"
         inputWrappedType.description == "Built-in ID"
 
+        // Nodes field
+        def fieldDef1 = type.fieldDefinitions[1]
+        fieldDef1.name == "nodes"
+        fieldDef1.description == "No Description"
+        fieldDef1.type instanceof GraphQLList
+        GraphQLList fieldDefType1 = (GraphQLList) fieldDef1.type
+        GraphQLInterfaceType wrappedType = (GraphQLInterfaceType) fieldDefType1.wrappedType
+        wrappedType.name == "Node"
+        wrappedType.description == "An object with an ID"
+        wrappedType.fieldDefinitions.size() == 1
+        def input1 = (GraphQLArgument) fieldDef1.arguments[0]
+        input1.name == "ids"
+        input1.description == "No Description"
+        input1.type instanceof GraphQLNonNull
+        def inputWrappedType1 = (GraphQLScalarType) ((GraphQLNonNull)input.type).wrappedType
+        inputWrappedType1.name == "ID"
+        inputWrappedType1.description == "Built-in ID"
+
         // Video field
-        def fieldDef2 = type.fieldDefinitions[1]
+        def fieldDef2 = type.fieldDefinitions[2]
         fieldDef2.name == "video"
         fieldDef2.description == "No Description"
         fieldDef2.type instanceof GraphQLObjectType
-        def GraphQLObjectType fieldDefType2 = (GraphQLObjectType) fieldDef2.type
+        GraphQLObjectType fieldDefType2 = (GraphQLObjectType) fieldDef2.type
         fieldDefType2.name == "Video"
         fieldDefType2.description == "No Description"
         fieldDefType2.fieldDefinitions.size() == 5
@@ -58,12 +77,12 @@ class TypeRegistryIntegrationTest extends Specification {
         inputWrappedType2.description == "Built-in ID"
 
         // Videos field
-        def fieldDef3 = type.fieldDefinitions[2]
+        def fieldDef3 = type.fieldDefinitions[3]
         fieldDef3.name == "videos"
         fieldDef3.description == "No Description"
         fieldDef3.arguments.name as Set == ["first", "after"] as Set
         fieldDef3.type instanceof GraphQLObjectType
-        def GraphQLObjectType fieldDefType3 = (GraphQLObjectType) fieldDef3.type
+        GraphQLObjectType fieldDefType3 = (GraphQLObjectType) fieldDef3.type
         fieldDefType3.name == "VideoConnection"
         fieldDefType3.description == "A connection to a list of items."
         fieldDefType3.fieldDefinitions.size() == 2


### PR DESCRIPTION
adding support for "ids" keyword - immediately useful in GlitrArgument to aid the creation of a Nodes endpoint