### PR TITLE
Fix bug in `sanitizeMethodName`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ maven.central.sync=false
 sonatype.username=DUMMY_SONATYPE_USER
 sonatype.password=DUMMY_SONATYPE_PASSWORD
 
-PROJECT_VERSION=1.1.2
+PROJECT_VERSION=1.1.4
 PROJECT_GITHUB_REPO_URL=https://github.com/nfl/glitr
 PROJECT_LICENSE_URL=https://github.com/nfl/glitr/blob/master/LICENSE

--- a/src/main/java/com/nfl/glitr/util/ReflectionUtil.java
+++ b/src/main/java/com/nfl/glitr/util/ReflectionUtil.java
@@ -85,11 +85,23 @@ public class ReflectionUtil {
                 .collect(Collectors.toMap(Method::getName, eligibleMethod -> Pair.of(eligibleMethod, eligibleMethod.getDeclaringClass()))));
     }
 
+    /**
+     * Strip a string from the prefix `get` or `is` and un-capitalize.
+     * @param name usually a getter name. e.g: `getTitle`
+     * @return sanitized name `title`
+     */
     public static String sanitizeMethodName(String name) {
-        return StringUtils.uncapitalize(
-                name.startsWith("is")
-                        ? name.substring(2)
-                        : name.substring(3));
+
+        String sanitized;
+        if (name.startsWith("is")) {
+            sanitized = name.substring(2);
+        } else if (name.startsWith("get")) {
+            sanitized = name.substring(3);
+        } else {
+            sanitized = name;
+        }
+
+        return StringUtils.uncapitalize(sanitized);
     }
 
     public static Type getActualTypeArgumentFromType(ParameterizedType parameterizedType) {

--- a/src/test/groovy/com/nfl/glitr/util/ReflectionUtilTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/util/ReflectionUtilTest.groovy
@@ -1,7 +1,6 @@
 package com.nfl.glitr.util
 
 import com.nfl.glitr.annotation.GlitrIgnore
-import com.nfl.glitr.util.ReflectionUtil
 import spock.lang.Specification
 
 class ReflectionUtilTest extends Specification {
@@ -28,15 +27,15 @@ class ReflectionUtilTest extends Specification {
         ReflectionUtil.eligibleMethod(Video.getMethod(methodName)) == eligible
 
         where:
-        methodName                                      || eligible
-        "getTitle"                                      || true
-        "getId"                                         || true
-        "isValid"                                       || true
-        "nonGetterMethod"                               || false
-        "getTitleWithGlitrIgnoreOnField"                || false
-        "getTitleWithGlitrIgnoreOnGetter"               || false
-        "getTitleWithGlitrIgnoreOnBothFieldAndGetter"   || false
-        "getMap"                                        || false
+        methodName                                    || eligible
+        "getTitle"                                    || true
+        "getId"                                       || true
+        "isValid"                                     || true
+        "nonGetterMethod"                             || false
+        "getTitleWithGlitrIgnoreOnField"              || false
+        "getTitleWithGlitrIgnoreOnGetter"             || false
+        "getTitleWithGlitrIgnoreOnBothFieldAndGetter" || false
+        "getMap"                                      || false
     }
 
     class Video {
@@ -83,5 +82,21 @@ class ReflectionUtilTest extends Specification {
         def Map getMap() {
             return null
         }
+    }
+
+
+    def "check sanitizeMethodName works properly, (can accept short method names)"() {
+        expect:
+        ReflectionUtil.sanitizeMethodName(methodName) == sanitized
+
+        where:
+        methodName            || sanitized
+        "getId"               || "id"
+        "isEnabled"           || "enabled"
+        "getVIDEO"            || "vIDEO"
+        "l"                   || "l"
+        "or"                  || "or"
+        "and"                 || "and"
+        "aVeryLongMethodName" || "aVeryLongMethodName"
     }
 }


### PR DESCRIPTION
`ReflectionUtil.sanitizeMethodName` threw a String index out of range exception when passing methods of length less or equal to 2. 

I added a test and updated the method to behave properly.