### PR TITLE
support for dates as strings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ maven.central.sync=false
 sonatype.username=DUMMY_SONATYPE_USER
 sonatype.password=DUMMY_SONATYPE_PASSWORD
 
-PROJECT_VERSION=1.1.4
+PROJECT_VERSION=1.1.5
 PROJECT_GITHUB_REPO_URL=https://github.com/nfl/glitr
 PROJECT_LICENSE_URL=https://github.com/nfl/glitr/blob/master/LICENSE

--- a/src/main/java/com/nfl/glitr/registry/type/Scalars.java
+++ b/src/main/java/com/nfl/glitr/registry/type/Scalars.java
@@ -47,7 +47,7 @@ public class Scalars {
                     Instant instant = Instant.parse(time);
                     return serialize(instant);
                 } catch (RuntimeException ex) {
-                    // let the exception get thrown
+                    throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString(), ex);
                 }
             }
 
@@ -111,7 +111,7 @@ public class Scalars {
                     Instant instant = Instant.parse(time);
                     return serialize(instant);
                 } catch (RuntimeException ex) {
-                    // let the exception get thrown
+                    throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString(), ex);
                 }
             }
 

--- a/src/main/java/com/nfl/glitr/registry/type/Scalars.java
+++ b/src/main/java/com/nfl/glitr/registry/type/Scalars.java
@@ -41,6 +41,17 @@ public class Scalars {
                 return formatter.format(time);
             }
 
+            if (input instanceof String) {
+                String time = (String) input;
+
+                try {
+                    Instant instant = Instant.parse(time);
+                    return serialize(instant);
+                } catch (RuntimeException ex) {
+                    // let the exception get thrown
+                }
+            }
+
             throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString());
         }
 

--- a/src/main/java/com/nfl/glitr/registry/type/Scalars.java
+++ b/src/main/java/com/nfl/glitr/registry/type/Scalars.java
@@ -47,7 +47,7 @@ public class Scalars {
                     Instant instant = Instant.parse(time);
                     return serialize(instant);
                 } catch (RuntimeException ex) {
-                    throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString(), ex);
+                    throw new IllegalArgumentException("Failed to parse/serialize GraphQLDateTime with value "+input.toString()+". Value likely of an unsupported format.", ex);
                 }
             }
 
@@ -111,11 +111,11 @@ public class Scalars {
                     Instant instant = Instant.parse(time);
                     return serialize(instant);
                 } catch (RuntimeException ex) {
-                    throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString(), ex);
+                    throw new IllegalArgumentException("Failed to parse/serialize GraphQLDate with value "+input.toString()+". Value likely of an unsupported format.", ex);
                 }
             }
 
-            throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString());
+            throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+input.toString());
         }
 
         @Override

--- a/src/main/java/com/nfl/glitr/registry/type/Scalars.java
+++ b/src/main/java/com/nfl/glitr/registry/type/Scalars.java
@@ -42,9 +42,8 @@ public class Scalars {
             }
 
             if (input instanceof String) {
-                String time = (String) input;
-
                 try {
+                    String time = (String) input;
                     Instant instant = Instant.parse(time);
                     return serialize(instant);
                 } catch (RuntimeException ex) {
@@ -104,6 +103,16 @@ public class Scalars {
             if (input instanceof Instant) {
                 Instant time = (Instant)input;
                 return formatter.format(time);
+            }
+
+            if (input instanceof String) {
+                try {
+                    String time = (String) input;
+                    Instant instant = Instant.parse(time);
+                    return serialize(instant);
+                } catch (RuntimeException ex) {
+                    // let the exception get thrown
+                }
             }
 
             throw new IllegalArgumentException("Can't serialize type "+input.getClass()+" with value "+ input.toString());

--- a/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
@@ -30,6 +30,7 @@ public class ScalarsTest extends Specification {
         Instant.parse("2016-01-08T00:32:09.132Z")       | "2016-01-08T00:32:09.132Z"
         Instant.ofEpochMilli(1454362550000l)            | "2016-02-01T21:35:50.000Z"
         ZonedDateTime.parse("2016-01-08T00:32:09.132Z") | "2016-01-08T00:32:09.132Z"
+        "2016-01-08T00:32:09.132Z"                           | "2016-01-08T00:32:09.132Z"
         null                                            | null
     }
 

--- a/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
@@ -67,7 +67,8 @@ public class ScalarsTest extends Specification {
         Instant.parse("2016-01-08T00:32:09.132Z")       | "2016-01-08"
         Instant.ofEpochMilli(1454362550000l)            | "2016-02-01"
         ZonedDateTime.parse("2016-01-08T00:32:09.132Z") | "2016-01-08"
-        LocalDate.of(2015, 01, 01)                      | "2015-01-01"
+        LocalDate.of(2015, 01, 01)   | "2015-01-01"
+        "2016-01-08T00:32:09.132Z"                           | "2016-01-08"
         null                                            | null
     }
 

--- a/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
@@ -43,7 +43,7 @@ public class ScalarsTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.getMessage() == "Can't serialize type class java.lang.String with value "+ input
+        e.getMessage() == "Failed to parse/serialize GraphQLDateTime with value "+input+". Value likely of an unsupported format."
     }
 
 
@@ -81,6 +81,6 @@ public class ScalarsTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.getMessage() == "Can't serialize type class java.lang.String with value "+ input
+        e.getMessage() == "Failed to parse/serialize GraphQLDate with value "+input+". Value likely of an unsupported format."
     }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/ScalarsTest.groovy
@@ -30,7 +30,7 @@ public class ScalarsTest extends Specification {
         Instant.parse("2016-01-08T00:32:09.132Z")       | "2016-01-08T00:32:09.132Z"
         Instant.ofEpochMilli(1454362550000l)            | "2016-02-01T21:35:50.000Z"
         ZonedDateTime.parse("2016-01-08T00:32:09.132Z") | "2016-01-08T00:32:09.132Z"
-        "2016-01-08T00:32:09.132Z"                           | "2016-01-08T00:32:09.132Z"
+        "2016-01-08T00:32:09.132Z"                      | "2016-01-08T00:32:09.132Z"
         null                                            | null
     }
 
@@ -67,8 +67,8 @@ public class ScalarsTest extends Specification {
         Instant.parse("2016-01-08T00:32:09.132Z")       | "2016-01-08"
         Instant.ofEpochMilli(1454362550000l)            | "2016-02-01"
         ZonedDateTime.parse("2016-01-08T00:32:09.132Z") | "2016-01-08"
-        LocalDate.of(2015, 01, 01)   | "2015-01-01"
-        "2016-01-08T00:32:09.132Z"                           | "2016-01-08"
+        LocalDate.of(2015, 01, 01)                      | "2015-01-01"
+        "2016-01-08T00:32:09.132Z"                      | "2016-01-08"
         null                                            | null
     }
 


### PR DESCRIPTION
support for dates as strings in the serialize method. this is effectively a format check and added since ExecutionStrategy calls serialize.