### PR TITLE
Update to graphql-java:4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
     // GraphQL dependencies
-    compile("com.graphql-java:graphql-java:2.3.0")
+    compile("com.graphql-java:graphql-java:4.2")
 
     // Commons dependencies
     compile("org.apache.commons:commons-lang3:3.4")

--- a/src/main/java/com/nfl/glitr/relay/PageInfoWithTotal.java
+++ b/src/main/java/com/nfl/glitr/relay/PageInfoWithTotal.java
@@ -1,11 +1,16 @@
 package com.nfl.glitr.relay;
 
-import graphql.relay.PageInfo;
+import graphql.relay.ConnectionCursor;
+import graphql.relay.DefaultPageInfo;
 
-public class PageInfoWithTotal extends PageInfo {
+public class PageInfoWithTotal extends DefaultPageInfo {
 
     private int total;
 
+    public PageInfoWithTotal(ConnectionCursor startCursor, ConnectionCursor endCursor,
+                             boolean hasPreviousPage, boolean hasNextPage) {
+        super(startCursor, endCursor, hasPreviousPage, hasNextPage);
+    }
 
     public int getTotal() {
         return total;

--- a/src/test/groovy/com/nfl/glitr/data/circularReference/CircularReferenceTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/data/circularReference/CircularReferenceTest.groovy
@@ -3,6 +3,7 @@ package com.nfl.glitr.data.circularReference
 import com.nfl.glitr.Glitr
 import com.nfl.glitr.GlitrBuilder
 import com.nfl.glitr.data.query.QueryType
+import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
@@ -20,7 +21,8 @@ class CircularReferenceTest extends Specification {
         type instanceof GraphQLInterfaceType
         type.name == AbstractRead.simpleName
         then: "And make sure the implementing type has the interface registered"
-        def objType = glitr.typeRegistry.getType(new Novel())
+        def objType = glitr.typeRegistry.getType(new TypeResolutionEnvironment(new Novel(),
+                null, null, null, null))
         objType.class == GraphQLObjectType
         objType.name == Novel.simpleName
         objType.fieldDefinitions.name as Set == ["novel", "pageCount", "title", "reviewed"] as Set
@@ -36,7 +38,8 @@ class CircularReferenceTest extends Specification {
         type instanceof GraphQLInterfaceType
         type.name == Readable.simpleName
         then: "And make sure the implementing type has the interface registered"
-        def objType = glitr.typeRegistry.getType(new Book())
+        def objType = glitr.typeRegistry.getType(new TypeResolutionEnvironment(new Book(),
+                null, null, null, null))
         objType.class == GraphQLObjectType
         objType.name == Book.simpleName
         objType.fieldDefinitions.name as Set == ["title", "synopsis"] as Set

--- a/src/test/groovy/com/nfl/glitr/data/query/QueryType.java
+++ b/src/test/groovy/com/nfl/glitr/data/query/QueryType.java
@@ -2,7 +2,6 @@ package com.nfl.glitr.data.query;
 
 import com.nfl.glitr.annotation.GlitrArgument;
 import com.nfl.glitr.annotation.GlitrForwardPagingArguments;
-import com.nfl.glitr.relay.*;
 
 import java.util.List;
 

--- a/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
@@ -6,6 +6,7 @@ import com.nfl.glitr.data.query.additionalTypes.Cyborg
 import com.nfl.glitr.data.query.additionalTypes.Man
 import com.nfl.glitr.data.query.additionalTypes.QueryRoot
 import com.nfl.glitr.util.SerializationUtil
+import graphql.TypeResolutionEnvironment
 import spock.lang.Specification
 
 class GlitrAdditionalTypesTest extends Specification {
@@ -16,17 +17,21 @@ class GlitrAdditionalTypesTest extends Specification {
                 .withObjectMapper(SerializationUtil.objectMapper)
                 .withQueryRoot(new QueryRoot())
                 .build()
+
+        def typeResolutionEnvMan = new TypeResolutionEnvironment(new Man(), null, null, null, null)
+        def typeResolutionEnvCyborg = new TypeResolutionEnvironment(new Cyborg(), null, null, null, null)
+
         then: "incidentally Man and Cyborg by default have not been discovered"
-        glitr.typeRegistry.getType(new Man()) == null
-        glitr.typeRegistry.getType(new Cyborg()) == null
+        glitr.typeRegistry.getType(typeResolutionEnvMan) == null
+        glitr.typeRegistry.getType(typeResolutionEnvCyborg) == null
 
         when: "add additional types to type registry and reload the schema"
         glitr.typeRegistry.lookup(Man.class)
         glitr.typeRegistry.lookup(Cyborg.class)
         glitr.reloadSchema(QueryRoot.class, null)
         then: "Man and Cyborg are now part of the schema"
-        glitr.typeRegistry.getType(new Man()) != null
-        glitr.typeRegistry.getType(new Cyborg()) != null
+        glitr.typeRegistry.getType(typeResolutionEnvMan) != null
+        glitr.typeRegistry.getType(typeResolutionEnvCyborg) != null
         glitr.schema.getType(Man.class.simpleName) != null
         glitr.schema.getType(Cyborg.class.simpleName) != null
     }

--- a/src/test/groovy/com/nfl/glitr/registry/GlitrRegisterAdditionalScalars.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/GlitrRegisterAdditionalScalars.groovy
@@ -5,6 +5,7 @@ import com.nfl.glitr.GlitrBuilder
 import com.nfl.glitr.data.additionalScalars.CustomScalar
 import com.nfl.glitr.data.additionalScalars.Root
 import graphql.Scalars
+import graphql.TypeResolutionEnvironment
 import spock.lang.Specification
 
 class GlitrRegisterAdditionalScalars extends Specification {
@@ -15,8 +16,9 @@ class GlitrRegisterAdditionalScalars extends Specification {
                 .withQueryRoot(new Root())
                 .addCustomScalar(CustomScalar.class, Scalars.GraphQLString)
                 .build()
+        def typeResolutionEnv = new TypeResolutionEnvironment(new Root(), null, null, null, null)
         then: "make sure the scalar has been registered correctly as a GraphQLString"
-        glitr.typeRegistry.getType(new Root()).getFieldDefinition("scalar").type.name == Scalars.GraphQLString.name
+        glitr.typeRegistry.getType(typeResolutionEnv).getFieldDefinition("scalar").type.name == Scalars.GraphQLString.name
     }
 
     def "Register twice the same custom scalar should fail"() {

--- a/src/test/groovy/com/nfl/glitr/registry/datafetcher/query/CompositeDataFetcherTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/datafetcher/query/CompositeDataFetcherTest.groovy
@@ -2,6 +2,7 @@ package com.nfl.glitr.registry.datafetcher.query
 
 import graphql.Scalars
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingEnvironmentBuilder
 import graphql.schema.PropertyDataFetcher
 import spock.lang.Specification
 
@@ -9,7 +10,10 @@ class CompositeDataFetcherTest extends Specification {
 
     def propertyDataFetcher = new PropertyDataFetcher("title")
     def overrideDataFetcher = new OverrideDataFetcher("title", new Override())
-    def env = new DataFetchingEnvironment(new DummyClass(), null, null, null, Scalars.GraphQLString, null, null);
+    def env = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
+                                        .source(new DummyClass())
+                                        .fieldType(Scalars.GraphQLString)
+                                        .build()
 
     def "Should iterate over dataFetchers until override gets called & return null when not found"() {
         expect:

--- a/src/test/groovy/com/nfl/glitr/registry/datafetcher/query/OverrideDataFetcherTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/datafetcher/query/OverrideDataFetcherTest.groovy
@@ -2,11 +2,15 @@ package com.nfl.glitr.registry.datafetcher.query
 
 import graphql.Scalars
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingEnvironmentBuilder
 import spock.lang.Specification
 
 class OverrideDataFetcherTest extends Specification {
 
-    def env = new DataFetchingEnvironment(new DummyClass(), null, null, null, Scalars.GraphQLString, null, null);
+    def env = DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
+            .source(new DummyClass())
+            .fieldType(Scalars.GraphQLString)
+            .build()
 
     def "override method in Override class"() {
         expect:

--- a/src/test/groovy/com/nfl/glitr/relay/RelayHelperTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/relay/RelayHelperTest.groovy
@@ -53,12 +53,12 @@ class RelayHelperTest extends Specification {
         assert pageInfoWithTotal.total == totalCount
 
         if (resultSize > 0) {
-            assert (connection.pageInfo.startCursor?.value == graphql.relay.Base64.toBase64("simple-cursor${toSkip}"))
-            assert (connection.pageInfo.endCursor?.value == graphql.relay.Base64.toBase64("simple-cursor${toSkip + resultSize - 1}"))
+            assert (connection.pageInfo.startCursor?.value == RelayHelper.Base64.toBase64("simple-cursor${toSkip}"))
+            assert (connection.pageInfo.endCursor?.value == RelayHelper.Base64.toBase64("simple-cursor${toSkip + resultSize - 1}"))
         }
 
         connection.edges.forEach({
-            assert (it.cursor.value == graphql.relay.Base64.toBase64("simple-cursor${it.node}"));
+            assert (it.cursor.value == RelayHelper.Base64.toBase64("simple-cursor${it.node}"));
         });
     }
 }


### PR DESCRIPTION
Fix compilation errors and fix double registration of the Node interface type.