### PR TITLE
Bump commons-beanutils to pull in commons-collections 3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-databind:2.6.2")
     compile ("net.objecthunter:exp4j:0.4.8")
 
-
     // Spock test dependencies
     testCompile("junit:junit:4.12")
     testCompile("cglib:cglib-nodep:3.2.4")  // for spock mocking, need later version for Java 8

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     // Commons dependencies
     compile("org.apache.commons:commons-lang3:3.4")
-    compile("commons-beanutils:commons-beanutils:1.9.2")
+    compile("commons-beanutils:commons-beanutils:1.9.3")
 
     // Google dependencies
     compile("com.google.code.findbugs:jsr305:3.0.0")


### PR DESCRIPTION
commons-beanutils 1.9.3 has a bump to commons-collection 3.2.2 which fixes a CVE
http://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.3/RELEASE-NOTES.txt

* BEANUTILS-482: Update commons-collections from 3.2.1 to 3.2.2
  (CVE-2015-4852). Thanks to Gary Gregory.