### PR TITLE
Use full class names in GraphQL introspection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ maven.central.sync=false
 sonatype.username=DUMMY_SONATYPE_USER
 sonatype.password=DUMMY_SONATYPE_PASSWORD
 
-PROJECT_VERSION=1.5.9
+PROJECT_VERSION=1.6.0
 PROJECT_GITHUB_REPO_URL=https://github.com/nfl/glitr
 PROJECT_LICENSE_URL=https://github.com/nfl/glitr/blob/master/LICENSE

--- a/src/main/java/com/nfl/glitr/registry/GlitrTypeMap.java
+++ b/src/main/java/com/nfl/glitr/registry/GlitrTypeMap.java
@@ -4,11 +4,12 @@ import com.nfl.glitr.exception.GlitrException;
 import graphql.schema.GraphQLType;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName;
 
 /**
  * A map implementation to sync the two kinds of registries currently in {@link com.nfl.glitr.registry.TypeRegistry}.
@@ -33,7 +34,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public Object putIfAbsent(Object key, Object value) {
         if (isClass(key)) {
-            nameRegistry.putIfAbsent(((Class) key).getSimpleName(), (GraphQLType) value);
+            nameRegistry.putIfAbsent(compatibleClassName((Class) key), (GraphQLType) value);
             return classRegistry.putIfAbsent((Class) key, (GraphQLType) value);
         } else if (isString(key)) {
             return nameRegistry.putIfAbsent((String) key, (GraphQLType) value);
@@ -44,7 +45,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public boolean remove(Object key, Object value) {
         if (isClass(key)) {
-            nameRegistry.remove(((Class) key).getSimpleName(), value);
+            nameRegistry.remove(compatibleClassName((Class) key), value);
             return classRegistry.remove(key, value);
         } else if (isString(key)) {
             return nameRegistry.remove(key, value);
@@ -55,7 +56,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public boolean replace(Object key, Object oldValue, Object newValue) {
         if (isClass(key)) {
-            nameRegistry.replace(((Class) key).getSimpleName(), (GraphQLType) oldValue, (GraphQLType) newValue);
+            nameRegistry.replace(compatibleClassName((Class) key), (GraphQLType) oldValue, (GraphQLType) newValue);
             return classRegistry.replace((Class) key, (GraphQLType) oldValue, (GraphQLType) newValue);
         } else if (isString(key)) {
             return nameRegistry.replace((String) key, (GraphQLType) oldValue, (GraphQLType) newValue);
@@ -66,7 +67,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public Object replace(Object key, Object value) {
         if (isClass(key)) {
-            nameRegistry.replace(((Class) key).getSimpleName(), (GraphQLType) value);
+            nameRegistry.replace(compatibleClassName((Class) key), (GraphQLType) value);
             return classRegistry.replace((Class) key, (GraphQLType) value);
         } else if (isString(key)) {
             return nameRegistry.replace((String) key, (GraphQLType) value);
@@ -107,7 +108,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public Object put(Object key, Object value) {
         if (isClass(key)) {
-            nameRegistry.put(((Class) key).getSimpleName(), (GraphQLType) value);
+            nameRegistry.put(compatibleClassName((Class) key), (GraphQLType) value);
             return classRegistry.put((Class) key, (GraphQLType) value);
         } else if (isString(key)) {
             return nameRegistry.put((String) key, (GraphQLType) value);
@@ -118,7 +119,7 @@ public class GlitrTypeMap implements ConcurrentMap {
     @Override
     public Object remove(Object key) {
         if (isClass(key)) {
-            nameRegistry.remove(((Class) key).getSimpleName());
+            nameRegistry.remove(compatibleClassName((Class) key));
             return classRegistry.remove(key);
         } else if (isString(key)) {
             return nameRegistry.remove(key);
@@ -144,7 +145,7 @@ public class GlitrTypeMap implements ConcurrentMap {
         if (isClass(next)) {
             for (Object o : m.entrySet()) {
                 Entry pair = (Entry) o;
-                nameRegistry.put(((Class) pair.getKey()).getSimpleName(), (GraphQLType) pair.getValue());
+                nameRegistry.put(compatibleClassName((Class) pair.getKey()), (GraphQLType) pair.getValue());
                 classRegistry.put((Class) pair.getKey(), (GraphQLType) pair.getValue());
             }
         } else if (isString(next)) {

--- a/src/main/java/com/nfl/glitr/registry/type/GraphQLEnumTypeFactory.java
+++ b/src/main/java/com/nfl/glitr/registry/type/GraphQLEnumTypeFactory.java
@@ -1,5 +1,6 @@
 package com.nfl.glitr.registry.type;
 
+import com.nfl.glitr.util.NamingUtil;
 import com.nfl.glitr.util.ReflectionUtil;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLType;
@@ -24,7 +25,7 @@ public class GraphQLEnumTypeFactory implements DelegateTypeFactory {
      */
     public static GraphQLEnumType createEnumType(Class clazz) {
         GraphQLEnumType.Builder builder = newEnum()
-                .name(clazz.getSimpleName())
+                .name(NamingUtil.compatibleClassName(clazz))
                 .description(ReflectionUtil.getDescriptionFromAnnotatedElement(clazz));
 
         for (Object constant : clazz.getEnumConstants()) {

--- a/src/main/java/com/nfl/glitr/registry/type/GraphQLInputObjectTypeFactory.java
+++ b/src/main/java/com/nfl/glitr/registry/type/GraphQLInputObjectTypeFactory.java
@@ -3,6 +3,7 @@ package com.nfl.glitr.registry.type;
 import com.googlecode.gentyref.GenericTypeReflector;
 import com.nfl.glitr.annotation.GlitrDescription;
 import com.nfl.glitr.registry.TypeRegistry;
+import com.nfl.glitr.util.NamingUtil;
 import com.nfl.glitr.util.ReflectionUtil;
 import com.nfl.glitr.exception.GlitrException;
 import graphql.schema.*;
@@ -48,7 +49,7 @@ public class GraphQLInputObjectTypeFactory implements DelegateTypeFactory {
                 .collect(Collectors.toList());
 
         GraphQLInputObjectType.Builder builder = newInputObject()
-                .name(clazz.getSimpleName())
+                .name(NamingUtil.compatibleClassName(clazz))
                 .description(ReflectionUtil.getDescriptionFromAnnotatedElement(clazz))
                 .fields(fields);
 

--- a/src/main/java/com/nfl/glitr/registry/type/GraphQLInterfaceTypeFactory.java
+++ b/src/main/java/com/nfl/glitr/registry/type/GraphQLInterfaceTypeFactory.java
@@ -7,6 +7,7 @@ import com.nfl.glitr.registry.TypeRegistry;
 import com.nfl.glitr.registry.datafetcher.query.batched.CompositeDataFetcherFactory;
 import com.nfl.glitr.registry.schema.GlitrFieldDefinition;
 import com.nfl.glitr.registry.schema.GlitrMetaDefinition;
+import com.nfl.glitr.util.NamingUtil;
 import com.nfl.glitr.util.ReflectionUtil;
 import graphql.language.InterfaceTypeDefinition;
 import graphql.schema.*;
@@ -53,7 +54,7 @@ public class GraphQLInterfaceTypeFactory implements DelegateTypeFactory {
                 .collect(Collectors.toList());
 
         return newInterface()
-                .name(clazz.getSimpleName())
+                .name(NamingUtil.compatibleClassName(clazz))
                 .definition(new InterfaceTypeDefinition(clazz.getCanonicalName()))
                 .description(ReflectionUtil.getDescriptionFromAnnotatedElement(clazz))
                 .typeResolver(typeRegistry)

--- a/src/main/java/com/nfl/glitr/registry/type/GraphQLObjectTypeFactory.java
+++ b/src/main/java/com/nfl/glitr/registry/type/GraphQLObjectTypeFactory.java
@@ -5,6 +5,7 @@ import com.nfl.glitr.annotation.GlitrQueryComplexity;
 import com.nfl.glitr.registry.TypeRegistry;
 import com.nfl.glitr.registry.schema.GlitrFieldDefinition;
 import com.nfl.glitr.registry.schema.GlitrMetaDefinition;
+import com.nfl.glitr.util.NamingUtil;
 import com.nfl.glitr.util.ReflectionUtil;
 import graphql.schema.*;
 import org.apache.commons.lang3.tuple.Pair;
@@ -70,7 +71,7 @@ public class GraphQLObjectTypeFactory implements DelegateTypeFactory {
         graphQLInterfaceTypes.addAll(graphQLAbstractClassTypes);
 
         GraphQLObjectType.Builder builder = newObject()
-                .name(clazz.getSimpleName())
+                .name(NamingUtil.compatibleClassName(clazz))
                 .description(ReflectionUtil.getDescriptionFromAnnotatedElement(clazz))
                 .withInterfaces(graphQLInterfaceTypes.toArray(new GraphQLInterfaceType[graphQLInterfaceTypes.size()]))
                 .fields(fields);
@@ -117,7 +118,7 @@ public class GraphQLObjectTypeFactory implements DelegateTypeFactory {
      * @return list of {@link GraphQLInterfaceType}
      */
     public List<GraphQLInterfaceType> retrieveInterfacesForType(Class clazz) {
-        List<GraphQLInterfaceType>  interfaceTypes = new ArrayList<>();
+        List<GraphQLInterfaceType> interfaceTypes = new ArrayList<>();
 
         LinkedList<Class> queue = new LinkedList<>();
         queue.add(clazz);
@@ -126,7 +127,7 @@ public class GraphQLObjectTypeFactory implements DelegateTypeFactory {
             Class aClass = queue.poll();
             Class<?>[] interfacesForClass = aClass.getInterfaces();
             queue.addAll(Arrays.asList(interfacesForClass));
-            for (Class interfaceClass: interfacesForClass) {
+            for (Class interfaceClass : interfacesForClass) {
                 GraphQLInterfaceType graphQLInterfaceType = (GraphQLInterfaceType) typeRegistry.lookupOutput(interfaceClass);
                 interfaceTypes.add(graphQLInterfaceType);
             }

--- a/src/main/java/com/nfl/glitr/relay/type/PagingOutputTypeConverter.java
+++ b/src/main/java/com/nfl/glitr/relay/type/PagingOutputTypeConverter.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.googlecode.gentyref.GenericTypeReflector;
 import com.nfl.glitr.exception.GlitrException;
 import com.nfl.glitr.relay.RelayHelper;
+import com.nfl.glitr.util.NamingUtil;
 import com.nfl.glitr.util.ReflectionUtil;
 import com.nfl.glitr.annotation.GlitrForwardPagingArguments;
 import com.nfl.glitr.annotation.GlitrNonNull;
@@ -22,6 +23,8 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
+
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName;
 
 /**
  *  Output type converter function for paging arguments annotations.
@@ -52,7 +55,7 @@ public class PagingOutputTypeConverter implements Func4<Field, Method, Class, An
         Class endEdgeClass =  ReflectionUtil.getClassFromType(endEdgeType);
 
         // find that class from the registry (or lookup if first time)
-        GraphQLOutputType edgeGraphQLOutputType = (GraphQLOutputType) typeRegistry.convertToGraphQLOutputType(endEdgeType, endEdgeClass.getSimpleName());
+        GraphQLOutputType edgeGraphQLOutputType = (GraphQLOutputType) typeRegistry.convertToGraphQLOutputType(endEdgeType, compatibleClassName(endEdgeClass));
 
         // is this an optional field
         boolean nullable = !method.isAnnotationPresent(GlitrNonNull.class)
@@ -63,12 +66,12 @@ public class PagingOutputTypeConverter implements Func4<Field, Method, Class, An
         }
 
         // build a relay edge
-        GraphQLObjectType edgeType = relayHelper.edgeType(endEdgeClass.getSimpleName(),
+        GraphQLObjectType edgeType = relayHelper.edgeType(compatibleClassName(endEdgeClass),
                                                     edgeGraphQLOutputType,
                                                     relayHelper.getNodeInterface(),
                                                     Collections.emptyList());
         // build the relay connection
-        GraphQLObjectType connectionType = relayHelper.connectionType(endEdgeClass.getSimpleName(), edgeType, Lists.newArrayList());
+        GraphQLObjectType connectionType = relayHelper.connectionType(compatibleClassName(endEdgeClass), edgeType, Lists.newArrayList());
 
         // check if a connection with this name already exists
         Map<String, GraphQLType> nameRegistry = typeRegistry.getNameRegistry();

--- a/src/main/java/com/nfl/glitr/util/NamingUtil.java
+++ b/src/main/java/com/nfl/glitr/util/NamingUtil.java
@@ -1,0 +1,25 @@
+package com.nfl.glitr.util;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Utility for providing names acceptable by graphql.
+ */
+public class NamingUtil {
+
+    /**
+     * Creates a graphql-compatible class name for the given class. Graphql doesn't accept
+     * dots as valid characters, so those are substituted by underscores. For example, it will
+     * make <tt>java.lang.Object</tt> into <tt>java_lang_Object</tt>.
+     *
+     * When naming subtypes, dollar signs will be replaced by double underscore characters, so
+     * <tt>com.nfl.glitr.registry.type.GraphQLEnumTypeFactoryTest$ProfileType</tt> becomes
+     * <tt>com_nfl_glitr_registry_type_GraphQLEnumTypeFactoryTest__ProfileType</tt>
+     *
+     * @param clazz the class to transform
+     * @return a transformed class name
+     */
+    public static String compatibleClassName(@NotNull Class clazz) {
+        return clazz.getName().replaceAll("\\.", "_").replaceAll("\\$", "__");
+    }
+}

--- a/src/main/java/com/nfl/glitr/util/ReflectionUtil.java
+++ b/src/main/java/com/nfl/glitr/util/ReflectionUtil.java
@@ -23,7 +23,7 @@ public class ReflectionUtil {
     public final static String NAME_PREFIX = "class ";
 
 
-    public static  String getClassName(Type type) {
+    public static String getClassName(Type type) {
         String fullName = type.toString();
         if (fullName.startsWith(NAME_PREFIX)) {
             return fullName.substring(NAME_PREFIX.length());
@@ -41,6 +41,7 @@ public class ReflectionUtil {
 
     /**
      * Determines if the given method is eligible for inclusion in the GraphQL Schema
+     *
      * @param method to inspect
      * @return true if the method name starts with `get` or `is` and false otherwise or if the method or the corresponding field is annotated with GlitrIgnore
      */
@@ -71,6 +72,7 @@ public class ReflectionUtil {
 
     /**
      * Returns an alphabetically sorted Map of the method names to the actual Method and referencing class
+     *
      * @param clazz to inspect
      * @return method map
      */
@@ -78,7 +80,9 @@ public class ReflectionUtil {
         List<Method> methods = Arrays.asList(clazz.getMethods());
         methods.stream()
                 .filter(method -> Collections.frequency(methods, method.getName()) > 1)
-                .forEach(duplicateMethodName -> { throw new IllegalArgumentException("Method name duplicate for the given field [" + duplicateMethodName.getName() + "] in class [" + clazz.getSimpleName() + "]"); });
+                .forEach(duplicateMethodName -> {
+                    throw new IllegalArgumentException("Method name duplicate for the given field [" + duplicateMethodName.getName() + "] in class [" + clazz.getName() + "]");
+                });
 
         return new TreeMap<>(methods.stream()
                 .filter(ReflectionUtil::eligibleMethod)
@@ -87,6 +91,7 @@ public class ReflectionUtil {
 
     /**
      * Strip a string from the prefix `get` or `is` and un-capitalize.
+     *
      * @param name usually a getter name. e.g: `getTitle`
      * @return sanitized name `title`
      */
@@ -113,8 +118,8 @@ public class ReflectionUtil {
     }
 
     public static GlitrArgument[] getArgumentsFromAnnotations(Map<Class, Annotation> annotationMap) {
-        GlitrArgument[] singleAnnotationGlitrArguments = annotationMap.containsKey(GlitrArgument.class) ? new GlitrArgument[] {(GlitrArgument)annotationMap.get(GlitrArgument.class)}  : new GlitrArgument[0];
-        GlitrArgument[] groupedAnnotationGlitrArguments = annotationMap.containsKey(GlitrArguments.class) ? ((GlitrArguments)annotationMap.get(GlitrArguments.class)).value() : new GlitrArgument[0];
+        GlitrArgument[] singleAnnotationGlitrArguments = annotationMap.containsKey(GlitrArgument.class) ? new GlitrArgument[]{(GlitrArgument) annotationMap.get(GlitrArgument.class)} : new GlitrArgument[0];
+        GlitrArgument[] groupedAnnotationGlitrArguments = annotationMap.containsKey(GlitrArguments.class) ? ((GlitrArguments) annotationMap.get(GlitrArguments.class)).value() : new GlitrArgument[0];
         return ArrayUtils.addAll(singleAnnotationGlitrArguments, groupedAnnotationGlitrArguments);
     }
 
@@ -135,7 +140,7 @@ public class ReflectionUtil {
 
     /**
      * Tells whether a given data fetcher supports batching
-     *  {code @Batched} on the get method or instance of {code BatchedDataFetcher}
+     * {code @Batched} on the get method or instance of {code BatchedDataFetcher}
      *
      * @param supplied data fetcher
      * @return true if batched, false otherwise
@@ -189,7 +194,7 @@ public class ReflectionUtil {
 
         if (Collection.class.isAssignableFrom(returnType) && method.getGenericReturnType() instanceof ParameterizedType) {
             try {
-                ParameterizedType pType = (ParameterizedType)method.getGenericReturnType();
+                ParameterizedType pType = (ParameterizedType) method.getGenericReturnType();
                 returnType = (Class<?>) pType.getActualTypeArguments()[0];
 
                 if (!isSupportedType(returnType)) {
@@ -209,6 +214,7 @@ public class ReflectionUtil {
 
     /**
      * Retrieves the GraphQL documentation description value if present on an element
+     *
      * @param element that may be annotated with the GlitrDescription
      * @return GlitrDescription.value if present or GlitrDescription.DEFAULT_DESCRIPTION otherwise
      */

--- a/src/test/groovy/com/nfl/glitr/data/circularReference/CircularReferenceTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/data/circularReference/CircularReferenceTest.groovy
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
 import spock.lang.Specification
 
-import static com.nfl.glitr.util.NodeUtil.buildNewPath
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName
 
 class CircularReferenceTest extends Specification {
 
@@ -20,14 +20,14 @@ class CircularReferenceTest extends Specification {
             GraphQLType type = glitr.typeRegistry.lookup(AbstractRead.class)
         then: "Make sure an interface is created"
             type instanceof GraphQLInterfaceType
-            type.name == AbstractRead.simpleName
+            type.name == compatibleClassName(AbstractRead)
         then: "And make sure the implementing type has the interface registered"
             def objType = glitr.typeRegistry.getType(new TypeResolutionEnvironment(new Novel(),
                     null, null, null, null, null))
             objType.class == GraphQLObjectType
-            objType.name == Novel.simpleName
+            objType.name == compatibleClassName(Novel)
             objType.fieldDefinitions.name as Set == ["novel", "pageCount", "title", "reviewed"] as Set
-            objType.interfaces.name as Set == [AbstractRead.simpleName] as Set
+            objType.interfaces.name as Set == [compatibleClassName(AbstractRead)] as Set
     }
 
     def "Inspect Interface that has a field circular reference"() {
@@ -37,13 +37,13 @@ class CircularReferenceTest extends Specification {
             GraphQLType type = glitr.typeRegistry.lookup(Readable.class)
         then: "Make sure an interface is created"
             type instanceof GraphQLInterfaceType
-            type.name == Readable.simpleName
+            type.name == compatibleClassName(Readable)
         then: "And make sure the implementing type has the interface registered"
             def objType = glitr.typeRegistry.getType(new TypeResolutionEnvironment(new Book(),
                     null, null, null, null, null))
             objType.class == GraphQLObjectType
-            objType.name == Book.simpleName
+            objType.name == compatibleClassName(Book)
             objType.fieldDefinitions.name as Set == ["title", "synopsis"] as Set
-            objType.interfaces.name as Set == [Readable.simpleName] as Set
+            objType.interfaces.name as Set == [compatibleClassName(Readable)] as Set
     }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
@@ -5,9 +5,14 @@ import com.nfl.glitr.GlitrBuilder
 import com.nfl.glitr.data.query.additionalTypes.Cyborg
 import com.nfl.glitr.data.query.additionalTypes.Man
 import com.nfl.glitr.data.query.additionalTypes.QueryRoot
+import com.nfl.glitr.dummy.Subscription
+import com.nfl.glitr.dummy.Viewer
+import com.nfl.glitr.util.NamingUtil
 import com.nfl.glitr.util.SerializationUtil
 import graphql.TypeResolutionEnvironment
 import spock.lang.Specification
+
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName
 
 class GlitrAdditionalTypesTest extends Specification {
 
@@ -32,7 +37,7 @@ class GlitrAdditionalTypesTest extends Specification {
         then: "Man and Cyborg are now part of the schema"
             glitr.typeRegistry.getType(typeResolutionEnvMan) != null
             glitr.typeRegistry.getType(typeResolutionEnvCyborg) != null
-            glitr.schema.getType(Man.class.simpleName) != null
-            glitr.schema.getType(Cyborg.class.simpleName) != null
+            glitr.schema.getType(compatibleClassName(Man)) != null
+            glitr.schema.getType(compatibleClassName(Cyborg)) != null
     }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/GlitrAdditionalTypesTest.groovy
@@ -5,9 +5,6 @@ import com.nfl.glitr.GlitrBuilder
 import com.nfl.glitr.data.query.additionalTypes.Cyborg
 import com.nfl.glitr.data.query.additionalTypes.Man
 import com.nfl.glitr.data.query.additionalTypes.QueryRoot
-import com.nfl.glitr.dummy.Subscription
-import com.nfl.glitr.dummy.Viewer
-import com.nfl.glitr.util.NamingUtil
 import com.nfl.glitr.util.SerializationUtil
 import graphql.TypeResolutionEnvironment
 import spock.lang.Specification

--- a/src/test/groovy/com/nfl/glitr/registry/TypeRegistryIntegrationTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/TypeRegistryIntegrationTest.groovy
@@ -11,259 +11,264 @@ import com.nfl.glitr.util.SerializationUtil
 import graphql.schema.*
 import spock.lang.Specification
 
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName
+
 class TypeRegistryIntegrationTest extends Specification {
 
     def "Inspect queryType"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr()
-                .withRelay()
-                .withObjectMapper(SerializationUtil.objectMapper)
-                .withQueryRoot(new QueryType())
-                .build()
+            Glitr glitr = GlitrBuilder.newGlitr()
+                    .withRelay()
+                    .withObjectMapper(SerializationUtil.objectMapper)
+                    .withQueryRoot(new QueryType())
+                    .build()
         when:
-        GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(QueryType.class)
+            GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(QueryType.class)
         then:
-        type.name == QueryType.class.getSimpleName()
-        type.description == GlitrDescription.DEFAULT_DESCRIPTION
+            type.name == compatibleClassName(QueryType)
+            type.description == GlitrDescription.DEFAULT_DESCRIPTION
 
-        // Relay Identifiable field
-        def fieldDef = type.fieldDefinitions[6]
-        fieldDef.name == "node"
-        fieldDef.description == null
-        fieldDef.type instanceof GraphQLInterfaceType
-        GraphQLInterfaceType fieldDefType = (GraphQLInterfaceType) fieldDef.type
-        fieldDefType.name == "Node"
-        fieldDefType.description == "An object with an ID"
-        fieldDefType.fieldDefinitions.size() == 1
-        def input = (GraphQLArgument) fieldDef.arguments[0]
-        input.name == "id"
-        input.description == GlitrArgument.DEFAULT_DESCRIPTION
-        input.type instanceof GraphQLNonNull
-        def inputWrappedType = (GraphQLScalarType) ((GraphQLNonNull)input.type).wrappedType
-        inputWrappedType.name == "ID"
-        inputWrappedType.description == "Built-in ID"
+            // Relay Identifiable field
+            def fieldDef = type.fieldDefinitions[6]
+            fieldDef.name == "node"
+            fieldDef.description == null
+            fieldDef.type instanceof GraphQLInterfaceType
+            GraphQLInterfaceType fieldDefType = (GraphQLInterfaceType) fieldDef.type
+            fieldDefType.name == "Node"
+            fieldDefType.description == "An object with an ID"
+            fieldDefType.fieldDefinitions.size() == 1
+            def input = (GraphQLArgument) fieldDef.arguments[0]
+            input.name == "id"
+            input.description == GlitrArgument.DEFAULT_DESCRIPTION
+            input.type instanceof GraphQLNonNull
+            def inputWrappedType = (GraphQLScalarType) ((GraphQLNonNull) input.type).wrappedType
+            inputWrappedType.name == "ID"
+            inputWrappedType.description == "Built-in ID"
 
-        // Nodes field
-        def fieldDef1 = type.fieldDefinitions[7]
-        fieldDef1.name == "nodes"
-        fieldDef1.description == null
-        fieldDef1.type instanceof GraphQLList
-        GraphQLList fieldDefType1 = (GraphQLList) fieldDef1.type
-        GraphQLInterfaceType wrappedType1 = (GraphQLInterfaceType) fieldDefType1.wrappedType
-        wrappedType1.name == "Node"
-        wrappedType1.description == "An object with an ID"
-        wrappedType1.fieldDefinitions.size() == 1
-        def input1 = (GraphQLArgument) fieldDef1.arguments[0]
-        input1.name == "ids"
-        input1.description == GlitrArgument.DEFAULT_DESCRIPTION
-        input1.type instanceof GraphQLNonNull
-        def inputWrappedType1 = (GraphQLScalarType) ((GraphQLNonNull)input.type).wrappedType
-        inputWrappedType1.name == "ID"
-        inputWrappedType1.description == "Built-in ID"
+            // Nodes field
+            def fieldDef1 = type.fieldDefinitions[7]
+            fieldDef1.name == "nodes"
+            fieldDef1.description == null
+            fieldDef1.type instanceof GraphQLList
+            GraphQLList fieldDefType1 = (GraphQLList) fieldDef1.type
+            GraphQLInterfaceType wrappedType1 = (GraphQLInterfaceType) fieldDefType1.wrappedType
+            wrappedType1.name == "Node"
+            wrappedType1.description == "An object with an ID"
+            wrappedType1.fieldDefinitions.size() == 1
+            def input1 = (GraphQLArgument) fieldDef1.arguments[0]
+            input1.name == "ids"
+            input1.description == GlitrArgument.DEFAULT_DESCRIPTION
+            input1.type instanceof GraphQLNonNull
+            def inputWrappedType1 = (GraphQLScalarType) ((GraphQLNonNull) input.type).wrappedType
+            inputWrappedType1.name == "ID"
+            inputWrappedType1.description == "Built-in ID"
 
-        // Other Video field
-        def fieldDef2 = type.fieldDefinitions[8]
-        fieldDef2.name == "otherVideos"
-        fieldDef2.description == null
-        fieldDef2.arguments.name as Set == ["first", "after"] as Set
-        fieldDef2.type instanceof GraphQLObjectType
-        GraphQLObjectType fieldDefType2 = (GraphQLObjectType) fieldDef2.type
-        fieldDefType2.name == "VideoConnection"
-        fieldDefType2.description == "A connection to a list of items."
-        fieldDefType2.fieldDefinitions.size() == 2
-        fieldDefType2.fieldDefinitions.name as Set == ["edges", "pageInfo"] as Set
+            // Other Video field
+            def fieldDef2 = type.fieldDefinitions[8]
+            fieldDef2.name == "otherVideos"
+            fieldDef2.description == null
+            fieldDef2.arguments.name as Set == ["first", "after"] as Set
+            fieldDef2.type instanceof GraphQLObjectType
+            GraphQLObjectType fieldDefType2 = (GraphQLObjectType) fieldDef2.type
+            fieldDefType2.name == "com_nfl_glitr_data_query_VideoConnection"
+            fieldDefType2.description == "A connection to a list of items."
+            fieldDefType2.fieldDefinitions.size() == 2
+            fieldDefType2.fieldDefinitions.name as Set == ["edges", "pageInfo"] as Set
 
-        // Video field
-        def fieldDef3 = type.fieldDefinitions[9]
-        fieldDef3.name == "video"
-        fieldDef3.description == null
-        fieldDef3.type instanceof GraphQLObjectType
-        GraphQLObjectType fieldDefType3 = (GraphQLObjectType) fieldDef3.type
-        fieldDefType3.name == "Video"
-        fieldDefType3.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDefType3.fieldDefinitions.size() == 11
-        def input3 = (GraphQLArgument) fieldDef3.arguments[0]
-        input3.name == "id"
-        input3.description == GlitrArgument.DEFAULT_DESCRIPTION
-        input3.type instanceof GraphQLNonNull
-        def inputWrappedType3 = (GraphQLScalarType) ((GraphQLNonNull)input3.type).wrappedType
-        inputWrappedType3.name == "ID"
-        inputWrappedType3.description == "Built-in ID"
+            // Video field
+            def fieldDef3 = type.fieldDefinitions[9]
+            fieldDef3.name == "video"
+            fieldDef3.description == null
+            fieldDef3.type instanceof GraphQLObjectType
+            GraphQLObjectType fieldDefType3 = (GraphQLObjectType) fieldDef3.type
+            fieldDefType3.name == "com_nfl_glitr_data_query_Video"
+            fieldDefType3.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDefType3.fieldDefinitions.size() == 11
+            def input3 = (GraphQLArgument) fieldDef3.arguments[0]
+            input3.name == "id"
+            input3.description == GlitrArgument.DEFAULT_DESCRIPTION
+            input3.type instanceof GraphQLNonNull
+            def inputWrappedType3 = (GraphQLScalarType) ((GraphQLNonNull) input3.type).wrappedType
+            inputWrappedType3.name == "ID"
+            inputWrappedType3.description == "Built-in ID"
 
-        // Videos field
-        def fieldDef4 = type.fieldDefinitions[10]
-        fieldDef4.name == "videos"
-        fieldDef4.description == null
-        fieldDef4.arguments.name as Set == ["first", "after"] as Set
-        fieldDef4.type instanceof GraphQLObjectType
-        GraphQLObjectType fieldDefType4 = (GraphQLObjectType) fieldDef4.type
-        fieldDefType4.name == "VideoConnection"
-        fieldDefType4.description == "A connection to a list of items."
-        fieldDefType4.fieldDefinitions.size() == 2
-        fieldDefType4.fieldDefinitions.name as Set == ["edges", "pageInfo"] as Set
+            // Videos field
+            def fieldDef4 = type.fieldDefinitions[10]
+            fieldDef4.name == "videos"
+            fieldDef4.description == null
+            fieldDef4.arguments.name as Set == ["first", "after"] as Set
+            fieldDef4.type instanceof GraphQLObjectType
+            GraphQLObjectType fieldDefType4 = (GraphQLObjectType) fieldDef4.type
+            fieldDefType4.name == "com_nfl_glitr_data_query_VideoConnection"
+            fieldDefType4.description == "A connection to a list of items."
+            fieldDefType4.fieldDefinitions.size() == 2
+            fieldDefType4.fieldDefinitions.name as Set == ["edges", "pageInfo"] as Set
 
-        // ZZZ Nodes field
-        def fieldDef5 = type.fieldDefinitions[12]
-        fieldDef5.name == "zZZNodes"
-        fieldDef5.description == null
-        fieldDef5.type instanceof GraphQLList
-        GraphQLList fieldDefType5 = (GraphQLList) fieldDef5.type
-        GraphQLInterfaceType wrappedType5 = (GraphQLInterfaceType) fieldDefType5.wrappedType
-        wrappedType5.name == "Node"
-        wrappedType5.description == "An object with an ID"
-        wrappedType5.fieldDefinitions.size() == 1
-        def input5 = (GraphQLArgument) fieldDef5.arguments[0]
-        input5.name == "ids"
-        input5.description == GlitrArgument.DEFAULT_DESCRIPTION
-        input5.type instanceof GraphQLNonNull
-        def inputWrappedType5 = (GraphQLScalarType) ((GraphQLNonNull)input.type).wrappedType
-        inputWrappedType5.name == "ID"
-        inputWrappedType5.description == "Built-in ID"
+            // ZZZ Nodes field
+            def fieldDef5 = type.fieldDefinitions[12]
+            fieldDef5.name == "zZZNodes"
+            fieldDef5.description == null
+            fieldDef5.type instanceof GraphQLList
+            GraphQLList fieldDefType5 = (GraphQLList) fieldDef5.type
+            GraphQLInterfaceType wrappedType5 = (GraphQLInterfaceType) fieldDefType5.wrappedType
+            wrappedType5.name == "Node"
+            wrappedType5.description == "An object with an ID"
+            wrappedType5.fieldDefinitions.size() == 1
+            def input5 = (GraphQLArgument) fieldDef5.arguments[0]
+            input5.name == "ids"
+            input5.description == GlitrArgument.DEFAULT_DESCRIPTION
+            input5.type instanceof GraphQLNonNull
+            def inputWrappedType5 = (GraphQLScalarType) ((GraphQLNonNull) input.type).wrappedType
+            inputWrappedType5.name == "ID"
+            inputWrappedType5.description == "Built-in ID"
 
-        // ZZZ Videos field
-        def fieldDef6 = type.fieldDefinitions[13]
-        fieldDef6.name == "zZZVideos"
-        fieldDef6.description == null
-        fieldDef6.type instanceof GraphQLList
-        GraphQLList fieldDefType6 = (GraphQLList) fieldDef6.type
-        GraphQLObjectType wrappedType6 = (GraphQLObjectType) fieldDefType6.wrappedType
-        wrappedType6.name == "Video"
-        wrappedType6.description == GlitrDescription.DEFAULT_DESCRIPTION
-        wrappedType6.fieldDefinitions.size() == 11
+            // ZZZ Videos field
+            def fieldDef6 = type.fieldDefinitions[13]
+            fieldDef6.name == "zZZVideos"
+            fieldDef6.description == null
+            fieldDef6.type instanceof GraphQLList
+            GraphQLList fieldDefType6 = (GraphQLList) fieldDef6.type
+            GraphQLObjectType wrappedType6 = (GraphQLObjectType) fieldDefType6.wrappedType
+            wrappedType6.name == "com_nfl_glitr_data_query_Video"
+            wrappedType6.description == GlitrDescription.DEFAULT_DESCRIPTION
+            wrappedType6.fieldDefinitions.size() == 11
     }
 
     def "Inspect Simple Object type"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(Bitrate.class)
+            GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(Bitrate.class)
         then:
-        type.name == Bitrate.class.getSimpleName()
-        type.description == GlitrDescription.DEFAULT_DESCRIPTION
-        type.fieldDefinitions.name == ["createdDate", "durationNanos", "frames", "grade", "gradeAverage", "id", "kbps", "modifiedDateTime", "url", "valid"]
-        type.interfaces.name as Set == ["Playable", "Identifiable"] as Set
-        def fieldDef = type.fieldDefinitions[0]
-        fieldDef.name == "createdDate"
-        fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef.type instanceof GraphQLScalarType
-        (fieldDef.type as GraphQLScalarType).name == "Date"
-        def fieldDef2 = type.fieldDefinitions[1]
-        fieldDef2.name == "durationNanos"
-        fieldDef2.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef2.type instanceof GraphQLScalarType
-        (fieldDef2.type as GraphQLScalarType).name == "Long"
-        def fieldDef8 = type.fieldDefinitions[2]
-        fieldDef8.name == "frames"
-        fieldDef8.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef8.type instanceof GraphQLList
-        def fieldDef3 = type.fieldDefinitions[3]
-        fieldDef3.name == "grade"
-        fieldDef3.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef3.type instanceof GraphQLScalarType
-        (fieldDef3.type as GraphQLScalarType).name == "Float"
-        def fieldDef4 = type.fieldDefinitions[4]
-        fieldDef4.name == "gradeAverage"
-        fieldDef4.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef4.type instanceof GraphQLScalarType
-        (fieldDef4.type as GraphQLScalarType).name == "Float"
-        def fieldDef5 = type.fieldDefinitions[5]
-        fieldDef5.name == "id"
-        fieldDef5.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef5.type instanceof GraphQLNonNull
-        ((fieldDef5.type as GraphQLNonNull).wrappedType as GraphQLScalarType).name == "ID"
-        def fieldDef6 = type.fieldDefinitions[6]
-        fieldDef6.name == "kbps"
-        fieldDef6.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef6.type instanceof GraphQLScalarType
-        (fieldDef6.type as GraphQLScalarType).name == "Int"
-        def fieldDef9 = type.fieldDefinitions[7]
-        fieldDef9.name == "modifiedDateTime"
-        fieldDef9.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef9.type instanceof GraphQLScalarType
-        (fieldDef9.type as GraphQLScalarType).name == "DateTime"
-        def fieldDef10 = type.fieldDefinitions[8]
-        fieldDef10.name == "url"
-        fieldDef10.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef10.type instanceof GraphQLScalarType
-        (fieldDef10.type as GraphQLScalarType).name == "String"
-        def fieldDef7 = type.fieldDefinitions[9]
-        fieldDef7.name == "valid"
-        fieldDef7.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef7.type instanceof GraphQLScalarType
-        (fieldDef7.type as GraphQLScalarType).name == "Boolean"
+            type.name == compatibleClassName(Bitrate)
+            type.description == GlitrDescription.DEFAULT_DESCRIPTION
+            type.fieldDefinitions.name == ["createdDate", "durationNanos", "frames", "grade", "gradeAverage", "id", "kbps", "modifiedDateTime", "url", "valid"]
+            type.interfaces.name as Set == ["com_nfl_glitr_data_query_Playable", "com_nfl_glitr_data_query_Identifiable"] as Set
+            def fieldDef = type.fieldDefinitions[0]
+            fieldDef.name == "createdDate"
+            fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef.type instanceof GraphQLScalarType
+            (fieldDef.type as GraphQLScalarType).name == "Date"
+            def fieldDef2 = type.fieldDefinitions[1]
+            fieldDef2.name == "durationNanos"
+            fieldDef2.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef2.type instanceof GraphQLScalarType
+            (fieldDef2.type as GraphQLScalarType).name == "Long"
+            def fieldDef8 = type.fieldDefinitions[2]
+            fieldDef8.name == "frames"
+            fieldDef8.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef8.type instanceof GraphQLList
+            def fieldDef3 = type.fieldDefinitions[3]
+            fieldDef3.name == "grade"
+            fieldDef3.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef3.type instanceof GraphQLScalarType
+            (fieldDef3.type as GraphQLScalarType).name == "Float"
+            def fieldDef4 = type.fieldDefinitions[4]
+            fieldDef4.name == "gradeAverage"
+            fieldDef4.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef4.type instanceof GraphQLScalarType
+            (fieldDef4.type as GraphQLScalarType).name == "Float"
+            def fieldDef5 = type.fieldDefinitions[5]
+            fieldDef5.name == "id"
+            fieldDef5.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef5.type instanceof GraphQLNonNull
+            ((fieldDef5.type as GraphQLNonNull).wrappedType as GraphQLScalarType).name == "ID"
+            def fieldDef6 = type.fieldDefinitions[6]
+            fieldDef6.name == "kbps"
+            fieldDef6.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef6.type instanceof GraphQLScalarType
+            (fieldDef6.type as GraphQLScalarType).name == "Int"
+            def fieldDef9 = type.fieldDefinitions[7]
+            fieldDef9.name == "modifiedDateTime"
+            fieldDef9.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef9.type instanceof GraphQLScalarType
+            (fieldDef9.type as GraphQLScalarType).name == "DateTime"
+            def fieldDef10 = type.fieldDefinitions[8]
+            fieldDef10.name == "url"
+            fieldDef10.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef10.type instanceof GraphQLScalarType
+            (fieldDef10.type as GraphQLScalarType).name == "String"
+            def fieldDef7 = type.fieldDefinitions[9]
+            fieldDef7.name == "valid"
+            fieldDef7.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef7.type instanceof GraphQLScalarType
+            (fieldDef7.type as GraphQLScalarType).name == "Boolean"
     }
 
     def "Inspect Enum type"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLEnumType type = (GraphQLEnumType) glitr.typeRegistry.lookup(ProfileType.class)
+            GraphQLEnumType type = (GraphQLEnumType) glitr.typeRegistry.lookup(ProfileType.class)
         then:
-        type.name == ProfileType.class.getSimpleName()
-        type.description == GlitrDescription.DEFAULT_DESCRIPTION
-        type.values.name as Set == [ProfileType.PLAYER.name(), ProfileType.COACH.name(), ProfileType.CHEERLEADER.name()] as Set
+            type.name == compatibleClassName(ProfileType)
+            type.description == GlitrDescription.DEFAULT_DESCRIPTION
+            type.values.name as Set == [ProfileType.PLAYER.name(), ProfileType.COACH.name(), ProfileType.CHEERLEADER.name()] as Set
     }
 
 
     def "Inspect Interface type"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(Identifiable.class)
+            GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(Identifiable.class)
         then:
-        type.name == Identifiable.class.getSimpleName()
-        type.description == "Identifiable interface needed for Relay"
-        def fieldDef = type.fieldDefinitions[0]
-        fieldDef.name == "id"
-        fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef.type instanceof GraphQLNonNull
-        (fieldDef.type as GraphQLNonNull).wrappedType instanceof GraphQLScalarType
-        def wrappedType = (GraphQLScalarType) (fieldDef.type as GraphQLNonNull).wrappedType
-        wrappedType.name == "ID"
-        fieldDef.dataFetcher instanceof CompositeDataFetcher
-        (fieldDef.dataFetcher as CompositeDataFetcher).fetchers[0] instanceof PropertyDataFetcher
+            type.name == compatibleClassName(Identifiable)
+            type.description == "Identifiable interface needed for Relay"
+            def fieldDef = type.fieldDefinitions[0]
+            fieldDef.name == "id"
+            fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef.type instanceof GraphQLNonNull
+            (fieldDef.type as GraphQLNonNull).wrappedType instanceof GraphQLScalarType
+            def wrappedType = (GraphQLScalarType) (fieldDef.type as GraphQLNonNull).wrappedType
+            wrappedType.name == "ID"
+            fieldDef.dataFetcher instanceof CompositeDataFetcher
+            (fieldDef.dataFetcher as CompositeDataFetcher).fetchers[0] instanceof PropertyDataFetcher
     }
 
     def "Inspect AbstractClass type"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(IdentifiableAbstractClass.class)
+            GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(IdentifiableAbstractClass.class)
         then:
-        type.name == IdentifiableAbstractClass.class.getSimpleName()
-        type.description == "Identifiable interface needed for Relay"
-        def fieldDef = type.fieldDefinitions[0]
-        fieldDef.name == "id"
-        fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDef.type instanceof GraphQLNonNull
-        (fieldDef.type as GraphQLNonNull).wrappedType instanceof GraphQLScalarType
-        def wrappedType = (GraphQLScalarType) (fieldDef.type as GraphQLNonNull).wrappedType
-        wrappedType.name == "ID"
-        fieldDef.dataFetcher instanceof CompositeDataFetcher
-        (fieldDef.dataFetcher as CompositeDataFetcher).fetchers[0] instanceof PropertyDataFetcher
+            type.name == compatibleClassName(IdentifiableAbstractClass)
+            type.description == "Identifiable interface needed for Relay"
+            def fieldDef = type.fieldDefinitions[0]
+            fieldDef.name == "id"
+            fieldDef.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDef.type instanceof GraphQLNonNull
+            (fieldDef.type as GraphQLNonNull).wrappedType instanceof GraphQLScalarType
+            def wrappedType = (GraphQLScalarType) (fieldDef.type as GraphQLNonNull).wrappedType
+            wrappedType.name == "ID"
+            fieldDef.dataFetcher instanceof CompositeDataFetcher
+            (fieldDef.dataFetcher as CompositeDataFetcher).fetchers[0] instanceof PropertyDataFetcher
     }
 
     def "Inspect Interface type that extends another interface"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(Playable.class)
+            GraphQLInterfaceType type = (GraphQLInterfaceType) glitr.typeRegistry.lookup(Playable)
         then: "Should inherit the fields from the super interfaces"
-        type.name == Playable.simpleName
-        type.fieldDefinitions.name == ["id", "url"]
+            type.name == compatibleClassName(Playable)
+            type.fieldDefinitions.name == ["id", "url"]
     }
 
 
     def "Inspect Simple Object type that extends an abstract class and interfaces"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr().withQueryRoot(new QueryType()).build()
         when:
-        GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(Video.class)
+            GraphQLObjectType type = (GraphQLObjectType) glitr.typeRegistry.lookup(Video.class)
         then: "Make sure it inherits the fields of the super classes"
-        type.name == Video.class.getSimpleName()
-        type.description == GlitrDescription.DEFAULT_DESCRIPTION
-        type.fieldDefinitions.name as Set == ["ignore", "children", "allVariablesComplexityFormula", "bitrateList", "depth", "id", "lastModifiedDate", "title", "totalCollectionsSize", "url", "fragments"] as Set
+            type.name == compatibleClassName(Video)
+            type.description == GlitrDescription.DEFAULT_DESCRIPTION
+            type.fieldDefinitions.name as Set == ["ignore", "children", "allVariablesComplexityFormula", "bitrateList", "depth", "id", "lastModifiedDate", "title", "totalCollectionsSize", "url", "fragments"] as Set
         then: "Make sure it implements the interfaces"
-        type.interfaces.name as Set == [AbstractContent.class.simpleName, AbstractTimestamped.class.simpleName, Identifiable.simpleName, Playable.class.simpleName] as Set
+            type.interfaces.name as Set == [compatibleClassName(AbstractContent),
+                                            compatibleClassName(AbstractTimestamped),
+                                            compatibleClassName(Identifiable),
+                                            compatibleClassName(Playable)] as Set
     }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/TypeRegistryMutationIntegrationTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/TypeRegistryMutationIntegrationTest.groovy
@@ -14,70 +14,72 @@ import graphql.schema.*
 import org.apache.commons.lang3.StringUtils
 import spock.lang.Specification
 
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName
+
 class TypeRegistryMutationIntegrationTest extends Specification {
 
     def "Inspect mutationType generated schema"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr()
-                .withQueryRoot(new QueryType()).build()
+            Glitr glitr = GlitrBuilder.newGlitr()
+                    .withQueryRoot(new QueryType()).build()
         when:
-        GraphQLObjectType mutationType = (GraphQLObjectType) glitr.typeRegistry.createRelayMutationType(MutationType.class)
+            GraphQLObjectType mutationType = (GraphQLObjectType) glitr.typeRegistry.createRelayMutationType(MutationType.class)
 
         then: "Check the mutation field"
-        mutationType.name == MutationType.class.getSimpleName()
-        mutationType.description == GlitrDescription.DEFAULT_DESCRIPTION
-        def fieldDef = mutationType.fieldDefinitions[0]
-        fieldDef.name == "saveVideoInfoMutation"
-        fieldDef.description == "Saves Info related to a video"
-        fieldDef.type instanceof GraphQLObjectType
+            mutationType.name == compatibleClassName(MutationType)
+            mutationType.description == GlitrDescription.DEFAULT_DESCRIPTION
+            def fieldDef = mutationType.fieldDefinitions[0]
+            fieldDef.name == "saveVideoInfoMutation"
+            fieldDef.description == "Saves Info related to a video"
+            fieldDef.type instanceof GraphQLObjectType
 
         then: "Check that output is correctly constructed"
-        def GraphQLObjectType fieldDefType = (GraphQLObjectType) fieldDef.type
-        fieldDefType.name == VideoMutationPayload.class.simpleName
-        fieldDefType.description == GlitrDescription.DEFAULT_DESCRIPTION
-        fieldDefType.fieldDefinitions.size() == 2
-        fieldDefType.fieldDefinitions.name as Set == ["clientMutationId", StringUtils.uncapitalize(VideoMutationPayload.class.simpleName)] as Set
-        def GraphQLObjectType fieldDefOutputType = (GraphQLObjectType) fieldDefType.fieldDefinitions[1].type
-        fieldDefOutputType.fieldDefinitions.size() == 4
-        fieldDefOutputType.fieldDefinitions.name as Set == ["url", "title", "bitrateList", "id"] as Set
+            def GraphQLObjectType fieldDefType = (GraphQLObjectType) fieldDef.type
+            fieldDefType.name == compatibleClassName(VideoMutationPayload)
+            fieldDefType.description == GlitrDescription.DEFAULT_DESCRIPTION
+            fieldDefType.fieldDefinitions.size() == 2
+            fieldDefType.fieldDefinitions.name as Set == ["clientMutationId", StringUtils.uncapitalize(VideoMutationPayload.simpleName)] as Set
+            def GraphQLObjectType fieldDefOutputType = (GraphQLObjectType) fieldDefType.fieldDefinitions[1].type
+            fieldDefOutputType.fieldDefinitions.size() == 4
+            fieldDefOutputType.fieldDefinitions.name as Set == ["url", "title", "bitrateList", "id"] as Set
 
         then: "Check that then input is correctly constructed"
-        def input = (GraphQLArgument) fieldDef.arguments[0]
-        input.name == "input"
-        input.description == GlitrArgument.DEFAULT_DESCRIPTION
-        input.defaultValue == "{default input}"
-        input.type instanceof GraphQLNonNull
-        def inputWrappedType = (GraphQLInputObjectType) ((GraphQLNonNull)input.type).wrappedType
-        inputWrappedType.name == "VideoMutationInput"
-        inputWrappedType.description == "Relay mutation input"
-        inputWrappedType.fields.each {it -> it instanceof GraphQLInputObjectField }
-        inputWrappedType.fields.name as Set == ["clientMutationId", "videoMutation"] as Set
-        def GraphQLInputObjectField fieldDefInputType = (GraphQLInputObjectField) inputWrappedType.fields[1]
-        fieldDefInputType.description == "Info meta data needed"
-        fieldDefInputType.defaultValue == null
-        fieldDefInputType.type instanceof GraphQLNonNull
-        def inputFieldWrappedType = (GraphQLInputObjectType) ((GraphQLNonNull)fieldDefInputType.type).wrappedType
-        inputFieldWrappedType.name == VideoMutationIn.class.simpleName
-        inputFieldWrappedType.description == GlitrDescription.DEFAULT_DESCRIPTION
-        inputFieldWrappedType.fields.name as Set == ["url", "title", "bitrateList"] as Set
-        inputFieldWrappedType.fields[1].type instanceof GraphQLScalarType
-        inputFieldWrappedType.fields[2].type instanceof GraphQLScalarType
-        inputFieldWrappedType.fields[0].type instanceof GraphQLList
-        inputFieldWrappedType.fields.defaultValue == [null, null, null]
+            def input = (GraphQLArgument) fieldDef.arguments[0]
+            input.name == "input"
+            input.description == GlitrArgument.DEFAULT_DESCRIPTION
+            input.defaultValue == "{default input}"
+            input.type instanceof GraphQLNonNull
+            def inputWrappedType = (GraphQLInputObjectType) ((GraphQLNonNull) input.type).wrappedType
+            inputWrappedType.name == "com_nfl_glitr_data_mutation_VideoMutationInput"
+            inputWrappedType.description == "Relay mutation input"
+            inputWrappedType.fields.each { it -> it instanceof GraphQLInputObjectField }
+            inputWrappedType.fields.name as Set == ["clientMutationId", "videoMutation"] as Set
+            def GraphQLInputObjectField fieldDefInputType = (GraphQLInputObjectField) inputWrappedType.fields[1]
+            fieldDefInputType.description == "Info meta data needed"
+            fieldDefInputType.defaultValue == null
+            fieldDefInputType.type instanceof GraphQLNonNull
+            def inputFieldWrappedType = (GraphQLInputObjectType) ((GraphQLNonNull) fieldDefInputType.type).wrappedType
+            inputFieldWrappedType.name == compatibleClassName(VideoMutationIn)
+            inputFieldWrappedType.description == GlitrDescription.DEFAULT_DESCRIPTION
+            inputFieldWrappedType.fields.name as Set == ["url", "title", "bitrateList"] as Set
+            inputFieldWrappedType.fields[1].type instanceof GraphQLScalarType
+            inputFieldWrappedType.fields[2].type instanceof GraphQLScalarType
+            inputFieldWrappedType.fields[0].type instanceof GraphQLList
+            inputFieldWrappedType.fields.defaultValue == [null, null, null]
     }
 
     def "Perform a mutation against mutationType"() {
         setup:
-        Glitr glitr = GlitrBuilder.newGlitr()
-                .withRelay()
-                .withQueryRoot(new QueryType())
-                .withMutationRoot(new MutationType())
-                .withObjectMapper(SerializationUtil.objectMapper)
-                .build()
+            Glitr glitr = GlitrBuilder.newGlitr()
+                    .withRelay()
+                    .withQueryRoot(new QueryType())
+                    .withMutationRoot(new MutationType())
+                    .withObjectMapper(SerializationUtil.objectMapper)
+                    .build()
 
-        GraphQL graphQL =  new GraphQL(glitr.getSchema());
+            GraphQL graphQL = new GraphQL(glitr.getSchema());
         when:
-        def result = graphQL.execute("""
+            def result = graphQL.execute("""
             mutation {
                 saveVideoInfoMutation(input: {
                     clientMutationId: \"mutationId-Sx160620160639713-1\"
@@ -92,11 +94,11 @@ class TypeRegistryMutationIntegrationTest extends Specification {
                 }
             }
         """);
-        def data = result.data
-        def errors = result.errors
+            def data = result.data
+            def errors = result.errors
         then:
-        errors.empty
-        (data as Map).saveVideoInfoMutation?.videoMutationPayload?.title == "My video title"
-        (data as Map).saveVideoInfoMutation?.clientMutationId == "mutationId-Sx160620160639713-1"
+            errors.empty
+            (data as Map).saveVideoInfoMutation?.videoMutationPayload?.title == "My video title"
+            (data as Map).saveVideoInfoMutation?.clientMutationId == "mutationId-Sx160620160639713-1"
     }
 }

--- a/src/test/groovy/com/nfl/glitr/registry/type/GraphQLEnumTypeFactoryTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/GraphQLEnumTypeFactoryTest.groovy
@@ -4,22 +4,24 @@ import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLType
 import spock.lang.Specification
 
+import static com.nfl.glitr.util.NamingUtil.compatibleClassName
+
 class GraphQLEnumTypeFactoryTest extends Specification {
 
     def "Java enum type to GraphQLEnumType"() {
         setup:
-        GraphQLEnumTypeFactory factory = new GraphQLEnumTypeFactory();
+            GraphQLEnumTypeFactory factory = new GraphQLEnumTypeFactory()
         when:
-        GraphQLType graphQLType = factory.create(ProfileType)
+            GraphQLType graphQLType = factory.create(ProfileType)
         then:
-        graphQLType instanceof GraphQLEnumType
-        def profileType = (GraphQLEnumType) graphQLType
-        profileType.name == ProfileType.simpleName
-        profileType.values.value == ProfileType.values()
+            graphQLType instanceof GraphQLEnumType
+            def profileType = (GraphQLEnumType) graphQLType
+            profileType.name == compatibleClassName(ProfileType)
+            profileType.values.value == ProfileType.values()
     }
 
 
-    public enum ProfileType {
+    enum ProfileType {
         PLAYER,
         COACH,
         CHEERLEADER

--- a/src/test/groovy/com/nfl/glitr/registry/type/GraphQLInputObjectTypeFactoryTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/registry/type/GraphQLInputObjectTypeFactoryTest.groovy
@@ -3,8 +3,9 @@ package com.nfl.glitr.registry.type
 import com.nfl.glitr.exception.GlitrException
 import com.nfl.glitr.registry.TypeRegistry
 import com.nfl.glitr.registry.TypeRegistryBuilder
+import com.nfl.glitr.util.NamingUtil
 import graphql.schema.GraphQLInputType
-import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLType
 import spock.lang.Specification
 
 public class GraphQLInputObjectTypeFactoryTest extends Specification {
@@ -18,7 +19,7 @@ public class GraphQLInputObjectTypeFactoryTest extends Specification {
         then:
         graphQLType instanceof GraphQLInputType
         def video = (GraphQLInputType) graphQLType
-        video.name == Test.simpleName
+        video.name == NamingUtil.compatibleClassName(Test)
     }
 
     def "Java class to GraphQLInputType with name already in use"() {

--- a/src/test/groovy/com/nfl/glitr/util/QueryComplexityCalculatorTest.groovy
+++ b/src/test/groovy/com/nfl/glitr/util/QueryComplexityCalculatorTest.groovy
@@ -1014,20 +1014,20 @@ class QueryComplexityCalculatorTest extends Specification {
         then:
             queryScore == expectedScore
         where:
-            variables             || query                                                                           || expectedScore
-            ""                    || "videosDepth{id}"                                                               || 1
-            ""                    || "videos{edges{node{depth{id}}}}"                                                || 3
-            ""                    || "videos{edges{node{children{edges{node{depth{id}}}}}}}"                         || 5
-            ""                    || "videos{edges{node{fragments{edges{node{... on Video{depth{id}}}}}}}}"          || 5
-            ""                    || "videos{edges{node{children{pageInfo{total}edges{node{depth{id}}}}}}}"          || 5
-            ""                    || "childScore{first{second{id}}}"                                                 || 4
-            ""                    || "currentCollectionSize(first: 3){id}"                                           || 3
-            ""                    || "currentCollectionSize(first: 3){totalCollectionsSize(first: 3){id}}"           || 9
-            'query($limit: Int!)' || 'currentCollectionSize(first: $limit){totalCollectionsSize(first: $limit){id}}' || 9
-            ""                    || "zZZVideos(first: 3){allVariablesComplexityFormula(first: 3){first{id}}}"       || 69
-            ""                    || "duplicateVariables{first{second{id}}}"                                         || 8
-            ""                    || "incorrectVariableDeclaration{id}"                                              || 0
-            ""                    || "abstract{url}"                                                                 || 6
+            variables             || query                                                                                           || expectedScore
+            ""                    || "videosDepth{id}"                                                                               || 1
+            ""                    || "videos{edges{node{depth{id}}}}"                                                                || 3
+            ""                    || "videos{edges{node{children{edges{node{depth{id}}}}}}}"                                         || 5
+            ""                    || "videos{edges{node{fragments{edges{node{... on com_nfl_glitr_data_query_Video{depth{id}}}}}}}}" || 5
+            ""                    || "videos{edges{node{children{pageInfo{total}edges{node{depth{id}}}}}}}"                          || 5
+            ""                    || "childScore{first{second{id}}}"                                                                 || 4
+            ""                    || "currentCollectionSize(first: 3){id}"                                                           || 3
+            ""                    || "currentCollectionSize(first: 3){totalCollectionsSize(first: 3){id}}"                           || 9
+            'query($limit: Int!)' || 'currentCollectionSize(first: $limit){totalCollectionsSize(first: $limit){id}}'                 || 9
+            ""                    || "zZZVideos(first: 3){allVariablesComplexityFormula(first: 3){first{id}}}"                       || 69
+            ""                    || "duplicateVariables{first{second{id}}}"                                                         || 8
+            ""                    || "incorrectVariableDeclaration{id}"                                                              || 0
+            ""                    || "abstract{url}"                                                                                 || 6
     }
 
     def "Calculate query complexity with fragment spread"() {


### PR DESCRIPTION
Updated Graphql key type introspection to identify types by full class name, and not by simple name. This should prevent collisions, when there are several classes with the same name in classpath.